### PR TITLE
Fix: 칼럼 기본값 설정 방식 변경

### DIFF
--- a/src/main/java/com/yongfill/server/domain/posts/entity/Post.java
+++ b/src/main/java/com/yongfill/server/domain/posts/entity/Post.java
@@ -42,16 +42,19 @@ public class Post {
     private LocalDateTime updateDate;
 
 
+    @ColumnDefault("0")
     @Column(name = "view_count", nullable = false)
-    private Long viewCount = 0L;
+    private Long viewCount;
 
 
+    @ColumnDefault("0")
     @Column(name = "like_count", nullable = false)
-    private Long likeCount = 0L;
+    private Long likeCount;
 
 
+    @ColumnDefault("N")
     @Column(name = "update_yn", length = 2, nullable = false)
-    private String updateYn = "N";
+    private String updateYn;
 
     @JoinColumn(name = "member_id", nullable = false)
     @ManyToOne


### PR DESCRIPTION
기존 방식이 QueryDSL과 충돌을 일으켜서 @ColumnDefault로 기본값을 설정했습니다.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [x] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
기존에 직접 엔터티에 기본값을 넣는 방식이 queryDSL이랑 충돌이 나서
ColumDefault 어노테이션을 이용했습니다
