### PR TITLE
Refactor: 카테고리별 게시글조회 구조 변경

### DIFF
--- a/src/main/java/com/yongfill/server/domain/posts/api/PostAPI.java
+++ b/src/main/java/com/yongfill/server/domain/posts/api/PostAPI.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RequiredArgsConstructor
 @RestController
@@ -31,13 +33,13 @@ public class PostAPI {
         return new ResponseEntity<>(postResponseDto,status);
     }
 
-//    @GetMapping("/api/categories/{category_name}/posts")
-//    public ResponseEntity<List<PostDto.PostResponseDto>> findAllByCategoryName(@PathVariable("category_name") String categoryName){
-//        HttpStatus status = HttpStatus.CREATED;
-//        List <PostDto.PostResponseDto> postResponseDto = postService.findAllByCategory(categoryName);
-//
-//        return new ResponseEntity<>(postResponseDto,status);
-//    }
+    @GetMapping("/api/categories/{category_name}/posts")
+    public ResponseEntity<List<ReadPostDto.ResponseDto>> findAllByCategoryName(@PathVariable("category_name") String categoryName){
+        HttpStatus status = HttpStatus.OK;
+        List <ReadPostDto.ResponseDto> postResponseDto = postService.findAllByCategory(categoryName);
+
+        return new ResponseEntity<>(postResponseDto,status);
+    }
 //
 //    @PatchMapping("/api/posts/{post_id}")
 //    public ResponseEntity<PostDto.PostResponseDto> updatePost(@PathVariable("post_id") Long postId,@RequestBody PostDto.CreateRequestDto createRequestDto){

--- a/src/main/java/com/yongfill/server/domain/posts/entity/Category.java
+++ b/src/main/java/com/yongfill/server/domain/posts/entity/Category.java
@@ -31,13 +31,13 @@ public enum Category implements EnumName<String> {
     //한글 이름으로 Category 객체를 반환
     public static Category fromKr(String kr) {
         if(kr == null) {
-            throw new CustomException(ErrorCode.CATEGORY_NAME_NOT_FOUND);
+            throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
         }
         for (Category category : Category.values()) {
             if (category.getKr().equals(kr)) {
                 return category;
             }
         }
-        throw new CustomException(ErrorCode.CATEGORY_NAME_NOT_FOUND);
+        throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
     }
 }

--- a/src/main/java/com/yongfill/server/domain/posts/service/PostService.java
+++ b/src/main/java/com/yongfill/server/domain/posts/service/PostService.java
@@ -4,6 +4,8 @@ import com.yongfill.server.domain.posts.dto.CreatePostDto;
 import com.yongfill.server.domain.posts.dto.ReadPostDto;
 import com.yongfill.server.domain.posts.entity.Post;
 
+import java.util.List;
+
 public interface PostService {
     //게시글 작성
     CreatePostDto.ResponseDto createPost(CreatePostDto.RequestDto dto);
@@ -11,6 +13,7 @@ public interface PostService {
     //게시글 상세 조회
     ReadPostDto.ResponseDto readPost(Long postId);
     //카테고리별 목록 조회
+    List<ReadPostDto.ResponseDto> findAllByCategory(String categoryName);
     
 
     

--- a/src/main/java/com/yongfill/server/domain/posts/service/PostServiceImpl.java
+++ b/src/main/java/com/yongfill/server/domain/posts/service/PostServiceImpl.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -55,16 +57,24 @@ public class PostServiceImpl implements PostService{
 
 
     };
-//    @Transactional(readOnly = true)
-//    public List<PostDto.PostResponseDto> findAllByCategory(String categoryName) {
-//
-//        Category category = Category.valueOf(categoryName);
-//        List<Post> posts = postJpaRepository.findAllByCategory(category);
-//
-//        return posts.stream()
-//                .map(this::entityToDto)
-//                .collect(Collectors.toList());
-//    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReadPostDto.ResponseDto> findAllByCategory(String categoryName) {
+
+        try{
+            Category category = Category.valueOf(categoryName);
+            List<Post> posts = postJpaRepository.findAllByCategory(category);
+
+            return posts.stream()
+                    .map(this::toDto)
+                    .collect(Collectors.toList());
+
+        }catch(IllegalArgumentException e){
+            throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
+        }
+
+    }
 
     //U
 

--- a/src/main/java/com/yongfill/server/global/common/response/error/ErrorCode.java
+++ b/src/main/java/com/yongfill/server/global/common/response/error/ErrorCode.java
@@ -13,7 +13,7 @@ import static org.springframework.http.HttpStatus.*;
 public enum ErrorCode {
     //CODE 400: BAD REQUEST
     CLIENT_BAD_REQUESTS(BAD_REQUEST,"잘못된 요청입니다."),
-    CATEGORY_NAME_NOT_FOUND(BAD_REQUEST,"존재하지 않는 카테고리 이름입니다."),
+    CATEGORY_NOT_FOUND(NOT_FOUND,"존재하지 않는 카테고리 이름입니다."),
     STACK_NAME_NOT_FOUND(BAD_REQUEST,"해당 스택이 존재하지 않습니다."),
     MEMBER_CREDIT_NOT_ENOUGH(BAD_REQUEST,"크래딧이 부족합니다."),
     DUPLICATE_MEMBER_EMAIL(BAD_REQUEST, "email이 중복 됩니다."),


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [x] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
Dto를 분리했으며,
PathVariable에 잘못된 카테고리 이름을 넣었을 경우,
Catogry Enum값을 찾는 과정에서 IllegalArgumentsException이 뜨므로 별도로 CustomException으로 잡아줬습니다

### 이슈 사항
http://localhost:8080/api/categories/QNA/posts

![image](https://github.com/user-attachments/assets/71b6b146-2397-46ed-8575-044ae61af76d)
아래는 잘못된 카테고리를 경로명에 넣었을 때
![image](https://github.com/user-attachments/assets/c22aab4d-5f22-4dff-a52e-9c951b3b415f)


