### PR TITLE
Feat: 게시글 삭제

### DIFF
--- a/src/main/java/com/yongfill/server/domain/posts/api/PostAPI.java
+++ b/src/main/java/com/yongfill/server/domain/posts/api/PostAPI.java
@@ -1,6 +1,7 @@
 package com.yongfill.server.domain.posts.api;
 
 import com.yongfill.server.domain.posts.dto.CreatePostDto;
+import com.yongfill.server.domain.posts.dto.DeletePostDto;
 import com.yongfill.server.domain.posts.dto.ReadPostDto;
 import com.yongfill.server.domain.posts.service.PostServiceImpl;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,13 @@ public class PostAPI {
         List <ReadPostDto.ResponseDto> postResponseDto = postService.findAllByCategory(categoryName);
 
         return new ResponseEntity<>(postResponseDto,status);
+    }
+
+    @DeleteMapping("/api/posts/{post_id}")
+    public ResponseEntity<DeletePostDto.ResponseDto> deletePost(@PathVariable("post_id")Long postId){
+        HttpStatus status = HttpStatus.OK;
+        DeletePostDto.ResponseDto deleteResponseDto= postService.deletePost(postId);
+        return new ResponseEntity<>(deleteResponseDto,status);
     }
 //
 //    @PatchMapping("/api/posts/{post_id}")

--- a/src/main/java/com/yongfill/server/domain/posts/dto/DeletePostDto.java
+++ b/src/main/java/com/yongfill/server/domain/posts/dto/DeletePostDto.java
@@ -1,0 +1,23 @@
+package com.yongfill.server.domain.posts.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+@Builder
+public class DeletePostDto {
+
+    @Builder
+    @Getter
+    public static class ResponseDto{
+        private HttpStatus status;
+        private String message;
+    }
+
+
+}

--- a/src/main/java/com/yongfill/server/domain/posts/service/PostService.java
+++ b/src/main/java/com/yongfill/server/domain/posts/service/PostService.java
@@ -1,6 +1,7 @@
 package com.yongfill.server.domain.posts.service;
 
 import com.yongfill.server.domain.posts.dto.CreatePostDto;
+import com.yongfill.server.domain.posts.dto.DeletePostDto;
 import com.yongfill.server.domain.posts.dto.ReadPostDto;
 import com.yongfill.server.domain.posts.entity.Post;
 
@@ -14,6 +15,7 @@ public interface PostService {
     ReadPostDto.ResponseDto readPost(Long postId);
     //카테고리별 목록 조회
     List<ReadPostDto.ResponseDto> findAllByCategory(String categoryName);
+    DeletePostDto.ResponseDto deletePost(Long postId);
     
 
     

--- a/src/main/java/com/yongfill/server/domain/posts/service/PostServiceImpl.java
+++ b/src/main/java/com/yongfill/server/domain/posts/service/PostServiceImpl.java
@@ -3,6 +3,7 @@ package com.yongfill.server.domain.posts.service;
 import com.yongfill.server.domain.member.entity.Member;
 import com.yongfill.server.domain.member.repository.MemberJpaRepository;
 import com.yongfill.server.domain.posts.dto.CreatePostDto;
+import com.yongfill.server.domain.posts.dto.DeletePostDto;
 import com.yongfill.server.domain.posts.dto.ReadPostDto;
 import com.yongfill.server.domain.posts.entity.Category;
 import com.yongfill.server.domain.posts.entity.Post;
@@ -11,6 +12,7 @@ import com.yongfill.server.global.common.response.error.ErrorCode;
 import com.yongfill.server.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,7 +82,21 @@ public class PostServiceImpl implements PostService{
 
 
     //D
+    public DeletePostDto.ResponseDto deletePost(Long postId){
+        //TODO: 인증인가 업데이트 ㅠㅠ
 
+        if (!postJpaRepository.existsById(postId)) {
+            throw new CustomException(ErrorCode.INVALID_POST);
+        }
+        postJpaRepository.deleteById(postId);
+
+        return DeletePostDto.ResponseDto
+                .builder()
+                .status(HttpStatus.NO_CONTENT)
+                .message("정상적으로 삭제되었습니다.")
+                .build();
+
+    }
 
     public Post toEntity(CreatePostDto.RequestDto dto){
         //TODO: 인증인가 업데이트ㅠㅠ (매개변수에 뭘 더 받아야함)


### PR DESCRIPTION
게시글을 삭제했습니다
마찬가지로 Dto를 CRUD에 따라 분리했습니다

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
게시글 삭제 API를 개발했습니다

### 이슈 사항
ResponseEntity에 HttpStatus를 NO_CONTENT로 설정할경우,
응답 API로 아무것도 오지 않습니다.
![image](https://github.com/user-attachments/assets/904ef4cf-fd90-439d-a131-e50a53f07089)

OK로 설정하면 의도한대로 정상적인 응답API가 출력되어 ResponseEntity의 Status를 OK로 변경했습니다
