### PR TITLE
Fix: 오답노트 당일 개수 조회answer API 커밋 다시 보내기

### DIFF
--- a/src/main/java/com/yongfill/server/domain/answer/api/MemberAnswerApi.java
+++ b/src/main/java/com/yongfill/server/domain/answer/api/MemberAnswerApi.java
@@ -4,7 +4,6 @@ import com.yongfill.server.domain.answer.dto.MemberAnswerDTO;
 import com.yongfill.server.domain.answer.entity.MemberAnswer;
 import com.yongfill.server.domain.answer.service.MemberAnswerService;
 import com.yongfill.server.domain.question.dto.InterviewQuestionDto;
-import com.yongfill.server.domain.question.entity.InterviewQuestion;
 import com.yongfill.server.global.common.dto.PageRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -33,9 +32,9 @@ public class MemberAnswerApi {
 
     @GetMapping("/api/members/{member_id}/stacks/{stack_id}/answers")
     public ResponseEntity<Page<InterviewQuestionDto.QuestionMemberAnswerResponseDTO>> findAnswers(@PathVariable("member_id") Long memberId,
-                                                                                     @PathVariable("stack_id") Long stackId,
-                                                                                     @RequestParam int page,
-                                                                                     @RequestParam int size){
+                                                                                                  @PathVariable("stack_id") Long stackId,
+                                                                                                  @RequestParam int page,
+                                                                                                  @RequestParam int size){
 
         HttpStatus status = HttpStatus.OK;
 
@@ -52,4 +51,11 @@ public class MemberAnswerApi {
         return new ResponseEntity<>(result, status);
     }
 
+    @GetMapping("/api/members/{member_id}/answers")
+    public ResponseEntity<MemberAnswerDTO.MemberAnswerCountDto> findCountTodayAnswer(@PathVariable("member_id")Long memberId){
+        HttpStatus status = HttpStatus.OK;
+        MemberAnswerDTO.MemberAnswerCountDto result = memberAnswerService.countTodayAnswer(memberId);
+
+        return new ResponseEntity<>(result,status);
+    }
 }

--- a/src/main/java/com/yongfill/server/domain/answer/dto/MemberAnswerDTO.java
+++ b/src/main/java/com/yongfill/server/domain/answer/dto/MemberAnswerDTO.java
@@ -69,6 +69,16 @@ public class MemberAnswerDTO {
             this.gptAnswer = gptAnswer;
             this.interviewMode = interviewMode;
         }
+
+    }
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class MemberAnswerCountDto {
+        private Long memberId;
+        private Long count;
+
     }
 
 

--- a/src/main/java/com/yongfill/server/domain/answer/repository/MemberAnswerJpaRepository.java
+++ b/src/main/java/com/yongfill/server/domain/answer/repository/MemberAnswerJpaRepository.java
@@ -2,8 +2,15 @@ package com.yongfill.server.domain.answer.repository;
 
 import com.yongfill.server.domain.answer.entity.MemberAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Repository
 public interface MemberAnswerJpaRepository extends JpaRepository<MemberAnswer, Long> {
+
+    Long countByMemberIdAndCreateDateBetween(Long memberId, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/yongfill/server/domain/answer/service/MemberAnswerService.java
+++ b/src/main/java/com/yongfill/server/domain/answer/service/MemberAnswerService.java
@@ -11,15 +11,13 @@ import com.yongfill.server.domain.question.dto.InterviewQuestionDto;
 import com.yongfill.server.domain.question.entity.InterviewQuestion;
 import com.yongfill.server.domain.question.repository.InterviewQuestionJpaRepository;
 import com.yongfill.server.domain.question.repository.InterviewQuestionQueryDSLRepository;
-import com.yongfill.server.domain.stack.entity.QuestionStack;
-import com.yongfill.server.domain.stack.repository.QuestionStackJpaRepository;
-import com.yongfill.server.global.common.dto.PageRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import static com.yongfill.server.global.common.response.error.ErrorCode.*;
@@ -33,7 +31,6 @@ public class MemberAnswerService {
     private final MemberJpaRepository memberJpaRepository;
     private final InterviewQuestionJpaRepository interviewQuestionJpaRepository;
     private final InterviewQuestionQueryDSLRepository interviewQuestionQueryDSLRepository;
-    private final QuestionStackJpaRepository questionStackJpaRepository;
 
 
     public MemberAnswer addMemberAnswer(MemberAnswerDTO.MemberAnswerRequestDTO memberAnswerRequestDTO) {
@@ -64,6 +61,19 @@ public class MemberAnswerService {
 
     }
 
+    public MemberAnswerDTO.MemberAnswerCountDto countTodayAnswer(Long memberId) {
+
+
+        LocalDateTime startOfDay = LocalDateTime.now().with(LocalTime.MIN);
+        LocalDateTime endOfDay = LocalDateTime.now().with(LocalTime.MAX);
+        Long count = memberAnswerJpaRepository.countByMemberIdAndCreateDateBetween(memberId,startOfDay,endOfDay);
+        return MemberAnswerDTO.MemberAnswerCountDto.builder()
+                .memberId(memberId)
+                .count(count)
+                .build();
+
+    }
+
     public MemberAnswer toEntity(MemberAnswerDTO.MemberAnswerRequestDTO dto, Member member, InterviewQuestion interviewQuestion) {
 
         return MemberAnswer.builder()
@@ -87,5 +97,6 @@ public class MemberAnswerService {
                 .build();
 
     }
+
 
 }


### PR DESCRIPTION


### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
오답노트 당일 개수 조회answer API를 만들었습니다.
member branch에서 해야하는데
자꾸 뻑이 나서 무서워서 여기서 보냅니다.....ㅠㅠ