### PR TITLE
Fix: 로그인 전 포스팅 상세조회 불가능 오류 해결

### DIFF
--- a/src/main/java/com/yongfill/server/domain/posts/api/PostAPI.java
+++ b/src/main/java/com/yongfill/server/domain/posts/api/PostAPI.java
@@ -40,8 +40,12 @@ public class PostAPI {
 
     @GetMapping("/api/posts/{post_id}")
     public ResponseEntity<ReadPostDto.DetailResponseDto> readPost(@PathVariable("post_id") Long postId,
-                                                                  @RequestHeader("Authorization") String accessToken) {
-        Long memberId = jwtTokenProvider.getUserIdFromToken(accessToken.substring(7));
+                                                                  @RequestHeader(value = "Authorization", required = false) String accessToken) {
+        //액세스 토큰이 없을 경우 memberId에 -1을 집어넣음
+        Long memberId = -1L;
+        if(accessToken != null){
+            memberId = jwtTokenProvider.getUserIdFromToken(accessToken.substring(7));
+        }
         HttpStatus status = HttpStatus.OK;
         ReadPostDto.DetailResponseDto postDetailResponseDto = postService.readPost(postId, memberId);
         return new ResponseEntity<>(postDetailResponseDto,status);

--- a/src/main/java/com/yongfill/server/domain/posts/service/PostService.java
+++ b/src/main/java/com/yongfill/server/domain/posts/service/PostService.java
@@ -64,8 +64,12 @@ public class PostService{
     //R
     @Transactional
     public ReadPostDto.DetailResponseDto readPost(Long postId, Long memberId) {
-        Member member = memberJpaRepository.findById(memberId)
-                .orElse(null);
+        Member member=null;
+
+        if(memberId==null){
+            member = memberJpaRepository.findById(memberId)
+                    .orElse(null);
+        }
 
         Post post = postJpaRepository.findById(postId)
                 .orElseThrow(()-> new CustomException(ErrorCode.INVALID_POST));


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [x] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
memberId가 null일경우 무조건적으로 오류가 납니다.
그래서 유저의 로그인 정보가 없을 경우, memberId를 -1로 넣어줬습니다.
memberId가 -1사람은 존재 안하니까ㅎ
